### PR TITLE
Update tsconfig.json to specify using the node module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "esnext",
+    "moduleResolution": "Node",
     "target": "es2020",
     "strict": true,
     "sourceMap": true,


### PR DESCRIPTION
["module": "esnext" defaults to 'classic'](https://www.typescriptlang.org/tsconfig#moduleResolution) which won't resolve via node_modules - so your sample works fine but the moment someone uses a library then they'll be a bit stuck

I was looking at tslib support via this repo  https://github.com/Urigo/typescript-node-es-modules-example/compare/master...orta:with_tslib?expand=1